### PR TITLE
Fix captcha validation response

### DIFF
--- a/src/TurnstileLaravel.php
+++ b/src/TurnstileLaravel.php
@@ -2,6 +2,8 @@
 
 namespace DerekCodes\TurnstileLaravel;
 
+use Exception;
+
 class TurnstileLaravel
 {
     public $secret_key;

--- a/src/TurnstileLaravel.php
+++ b/src/TurnstileLaravel.php
@@ -41,6 +41,8 @@ class TurnstileLaravel
                 $result = curl_exec($curl);
                 $err = curl_error($curl);
                 curl_close($curl);
+
+                $json = json_decode($result);
             } catch (Exception $e) {
                 return [
                     'status' => 0,

--- a/src/TurnstileLaravel.php
+++ b/src/TurnstileLaravel.php
@@ -14,7 +14,7 @@ class TurnstileLaravel
         }
     }
     
-    public function validate(String $response): Array
+    public function validate(String $response): array
     {
         if (!empty($this->secret_key)) {
             try {


### PR DESCRIPTION
Since v1.3 (latest release as of yet) the captcha is always failing due to `$json` variable never been defined. The return type is also `Array` instead of `array`.